### PR TITLE
Update 1771 - Marsa Alam.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/history/provinces/africa/1771 - Marsa Alam.txt
+++ b/Throne-of-Lorraine/TOL/history/provinces/africa/1771 - Marsa Alam.txt
@@ -1,5 +1,5 @@
-            
-add_core = COP
+add_core = SUD
+add_core = EGY
 trade_goods = wool
 life_rating = 10
 terrain = coastal_desert


### PR DESCRIPTION
The way GFM redrew the borders means that a Coptic Egypt that owns this province just looks awful. Since only bedouins live here, wouldn't it be better to leave it to Muslim Egypt/Nubia and Sudan?