### PR TITLE
Update ToL - COP.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/decisions/ToL - COP.txt
+++ b/Throne-of-Lorraine/TOL/decisions/ToL - COP.txt
@@ -20,7 +20,14 @@ political_decisions = {
 			905 = { add_core = COP }
 			TUR_894 = { add_core = COP }
 			EGY_915 = { add_core = COP }
-			badboy = 10
+			EGY_921 = { add_core = COP }
+			3362 = { add_core = COP }
+			902 = { add_core = COP }
+			3358 = { add_core = COP }
+			909 = { add_core = COP }
+			908 = { add_core = COP }
+			922 = { add_core = COP }
+			badboy = 15
 		}
 		ai_will_do = { factor = 1 }
 	}


### PR DESCRIPTION
Coptic decision to core the levant now cores every last coastal PLS, SYR, LBN, And CLC province settled by the Ottomans at 1836 start. Previously, it only cored Palestine, Lebanon and random provinces in Syria and Adana/Cilicia