### PR TITLE
Update PNT - Pontus.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/history/countries/PNT - Pontus.txt
+++ b/Throne-of-Lorraine/TOL/history/countries/PNT - Pontus.txt
@@ -1,5 +1,5 @@
 capital = 882
-primary_culture = greek
+primary_culture = neo_greek
 religion = orthodox
 government = absolute_monarchy
 plurality = 0.0


### PR DESCRIPTION
Biggest change yet. Make all greek pops east of the vertical line stretching from Cilicia to Kastamonu Neo-Greek. This allows a Georgia, Armenia and Khemet that blob to accept (After much research) the Neo greeks. We could justify it as the Neo greeks being in their lands for so long that the other language groups that surround them have made them minorities, while the Main Greeks were only recently conquered and so remain a majority.