### PR TITLE
Update ToL - COP.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/decisions/ToL - COP.txt
+++ b/Throne-of-Lorraine/TOL/decisions/ToL - COP.txt
@@ -25,6 +25,42 @@ political_decisions = {
 		ai_will_do = { factor = 1 }
 	}
 
+	embrace_the_syriacs = { 
+	potential = { 
+	     OR = {
+		 tag = COP
+		 tag = GEO
+	         tag = ARM
+		 tag = ASY
+	     }
+	     NOT = {
+                OR = {
+                    accepted_culture = syriac
+                    has_country_flag = embraced_syriac
+                }
+            }
+        }
+	
+	allow = {
+            year = 1850
+            prestige = 70
+	    owns = 917
+	    owns = 902
+	    owns = 900
+	    owns = 913
+	    owns = 897
+        }
+	
+	 effect = {
+            set_country_flag = embraced_syriac
+            add_accepted_culture = syriac
+            prestige = 25            
+        }
+        ai_will_do = {
+            factor = 1
+        }
+    }
+	
         embrace_the_misri = {
         picture = embrace_minority
         potential = {


### PR DESCRIPTION
Georgia, Khemet, Assyria, and Armenia have the decision to accept Syriac cultured pops if the year is after 1850, they have 70 prestige, and own Antioch, Jerusalem, Aleppo, Damascus and Beirut