### PR TITLE
Update issues.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/common/issues.txt
+++ b/Throne-of-Lorraine/TOL/common/issues.txt
@@ -420,17 +420,38 @@ political_reforms = {
         mandatory_service = {
             mobilisation_size = 0.06
             mobilisation_economy_impact = 1
+	    land_organisation = 0.1
+	    org_regain = 0.1
+	    leadership_modifier = 0.2
             land_unit_start_experience = 10
             global_immigrant_attract = -0.1
             education_efficiency_modifier = -0.01
+	    allow = {
+                OR = {
+                    NOT = { war_policy = pacifism }
+                    NOT = { war_policy = anti_military}
+                }
+            }
         }
         four_year_draft = {
             mobilisation_size = 0.04
             mobilisation_economy_impact = 0.1
+	    land_organisation = 0.075
+	    org_regain = 0.075
+	    leadership_modifier = 0.15
             land_unit_start_experience = 5
             global_immigrant_attract = -0.05
+	    allow = {
+                OR = {
+                    NOT = { war_policy = pacifism }
+                    NOT = { war_policy = anti_military}
+                }
+            }
         }
         two_year_draft = {
+	    land_organisation = 0.05
+	    org_regain = 0.05
+	    leadership_modifier = 0.10
             mobilisation_size = 0.02
             mobilisation_economy_impact = 0.05
         }
@@ -438,6 +459,7 @@ political_reforms = {
             mobilisation_size = 0.01
             global_immigrant_attract = 0.01
             land_unit_start_experience = -2
+	    leadership_modifier = -0.05
             allow = {
                 OR = {
                     NOT = { war_policy = jingoism }
@@ -448,6 +470,7 @@ political_reforms = {
         no_draft = {
             global_immigrant_attract = 0.03
             land_unit_start_experience = -5
+	    leadership_modifier = -0.10
             allow = {
                 OR = {
                     NOT = { war_policy = jingoism }


### PR DESCRIPTION
Conscription Policy Buffs:
-Mandatory Service now boosts organization by 10%, organization regain by 10% and leadership points gain by 20%
-Four Year Draft now boosts the organization by 7.5%, organization regain by 7.5% and leadership points gain by 15%
-Two Year Draft now boosts the organization by 5%, organization regain by 5% and leadership points gain by 10%
-Four Year Draft and Mandatory Service can no longer be implemented by Pacifist or Anti-War political parties
-One year Draft and No Draft now provide minus 5% and minus 10% leadership modifier respectively