### PR TITLE
Update Azerbaijan.txt

### DIFF
--- a/Throne-of-Lorraine/TOL/history/pops/1836.1.1/Azerbaijan.txt
+++ b/Throne-of-Lorraine/TOL/history/pops/1836.1.1/Azerbaijan.txt
@@ -745,7 +745,12 @@
     farmers = {
         culture = azerbaijani
         religion = shiite
-        size = 11800
+        size = 7000
     }
-
+     
+    farmers = {
+        culture = georgian
+        religion = orthodox
+        size = 4800
+    }
 }


### PR DESCRIPTION
3316 has no Georgian pops despite having being the only Azerbaijani province with a Georgian core. This is weird because the province to its east (further away from Georgia) has Georgian pops of its own. So, I fixed this by splitting off 4800 of the 11800 Azerbaijani farmers in this province and turned them into Georgian.